### PR TITLE
support for WANPPPConnection

### DIFF
--- a/pythonp2p/portforwardlib.py
+++ b/pythonp2p/portforwardlib.py
@@ -80,7 +80,7 @@ def get_wanip_path(upnp_url):
         # I'm using the fact that a 'serviceType' element contains a single text node, who's data can
         # be accessed by the 'data' attribute.
         # When I find the right element, I take a step up into its parent and search for 'controlURL'
-        if service.childNodes[0].data.find("WANIPConnection") > 0:
+        if service.childNodes[0].data.find("WANIPConnection") > 0 or service.childNodes[0].data.find("WANPPPConnection") > 0:
             path = (
                 service.parentNode.getElementsByTagName("controlURL")[0]
                 .childNodes[0]


### PR DESCRIPTION
I assume this check was intended to be added due to the comment above but missed
```
# this should also check for WANPPPConnection, which, if I remember correctly
# exposed a similar SOAP interface on ADSL routers.
```
Without this check `get_wanip_path` returns None on my ADSL router and fails to forward a port.
